### PR TITLE
Adding git-lfs to base pkgs

### DIFF
--- a/macos-init.sh
+++ b/macos-init.sh
@@ -27,7 +27,7 @@ base_cli=(
 	'gnu-tar --with-default-names' 'gnu-which --with-default-names' 'ed --with-default-names'
 	'findutils --with-default-names' 'grep --with-default-names' 'wdiff --with-gettext'
 	'ccat' 'gawk' 'gnutls' 'gzip' 'unzip' 'watch' 'wget' 'bash' 'less' 'most' 'make'
-	'git'
+	'git' 'git-lfs'
 );
 
 # base common cask tools


### PR DESCRIPTION
Its common enough for us to need to keep binaries in the repos, so we should be pre-install `git lfs` since itll be leveraged by most engineers on the team anyway.